### PR TITLE
Add allow restrictions to dev decisions

### DIFF
--- a/decisions/JasonGoldDecisions.txt
+++ b/decisions/JasonGoldDecisions.txt
@@ -5,6 +5,15 @@ country_decisions = {
         potential = {
             ai = no
         }
+        allow = {
+            any_owned_province = {
+                OR = {
+                    trade_goods = gold
+                    trade_goods = silver
+                }
+                NOT = { base_production = 25 }
+            }
+        }
         provinces_to_highlight = {
             OR = {
                 trade_goods = gold
@@ -64,6 +73,15 @@ country_decisions = {
         major = yes
         potential = {
             ai = no
+        }
+        allow = {
+            any_owned_province = {
+                OR = {
+                    trade_goods = silk
+                    trade_goods = dyes
+                }
+                NOT = { base_production = 25 }
+            }
         }
         provinces_to_highlight = {
             OR = {


### PR DESCRIPTION
## Summary
- limit `set_gold_dev` to provinces with gold or silver under 25 production
- limit `set_silk_dev` to silk or dye provinces under 25 production

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_683d39a436b8832bbe30fea6e32a05f4